### PR TITLE
Better handling of the codebehind file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -197,7 +197,8 @@ module.exports = {
         {
             files: ['*.spec.ts'],
             rules: {
-                '@typescript-eslint/no-unsafe-assignment': 'off'
+                '@typescript-eslint/no-unsafe-assignment': 'off',
+                '@typescript-eslint/no-unused-expressions': 'off'
             }
         }
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@types/chai": "^4.3.11",
+        "@types/fs-extra": "^11.0.4",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.10.7",
         "@typescript-eslint/eslint-plugin": "^5.30.7",
@@ -764,6 +765,16 @@
       "integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==",
       "dev": true
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -775,6 +786,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/mocha": {
       "version": "10.0.6",
@@ -7344,6 +7364,16 @@
       "integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "requires": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -7355,6 +7385,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/mocha": {
       "version": "10.0.6",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/chai": "^4.3.11",
+    "@types/fs-extra": "^11.0.4",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.10.7",
     "@typescript-eslint/eslint-plugin": "^5.30.7",

--- a/src/findNodes.spec.ts
+++ b/src/findNodes.spec.ts
@@ -1,9 +1,11 @@
-import { Program, util, standardizePath as s } from 'brighterscript';
+import type { XmlFile } from 'brighterscript';
+import { Program, util, standardizePath as s, AstEditor } from 'brighterscript';
 import { expect } from 'chai';
 import { Plugin } from './Plugin';
 import * as path from 'path';
 import undent from 'undent';
 import * as fsExtra from 'fs-extra';
+import { findChildrenWithIDs, findNodeWithIDInjection, validateNodeWithIDInjection } from './findNodes';
 const tempDir = s`${__dirname}/../.tmp`;
 const rootDir = s`${tempDir}/rootDir`;
 const stagingDir = s`${tempDir}/stagingDir`;
@@ -27,7 +29,73 @@ describe('findnode', () => {
         fsExtra.removeSync(tempDir);
     });
 
-    it('it works when a bs file is present', async () => {
+    describe('findChildrenWithIDs', () => {
+        it('does not crash on undefined children array', () => {
+            expect(
+                Object.entries(findChildrenWithIDs(undefined as any))
+            ).to.eql([]);
+        });
+
+        it('does not crash when child is missing id prop', () => {
+            expect(
+                Object.entries(findChildrenWithIDs([{} as any]))
+            ).to.eql([]);
+        });
+
+        it('does not crash when child is missing id prop', () => {
+            expect(
+                Object.entries(findChildrenWithIDs([{
+                    id: 1
+                } as any]))
+            ).to.eql([]);
+        });
+    });
+
+    describe('findNodeWithIDInjection', () => {
+        it('does not crash when is missing children', () => {
+            const file = program.setFile<XmlFile>('components/ZombieKeyboard.xml', `
+                <component name="ZombieKeyboard">
+                </component>
+            `);
+            delete file.parser.ast.component;
+
+            findNodeWithIDInjection(program, [], new AstEditor(), []);
+        });
+    });
+
+    describe('validateNodeWithIDInjection', () => {
+        it('does not crash when is missing children', () => {
+            const file = program.setFile<XmlFile>('components/ZombieKeyboard.xml', `
+                <component name="ZombieKeyboard">
+                </component>
+            `);
+            delete file.parser.ast.component;
+
+            validateNodeWithIDInjection(program);
+        });
+
+        it('does not crash on non-findnode calls', () => {
+            program.setFile<XmlFile>('components/ZombieKeyboard.xml', `
+                <component name="ZombieKeyboard">
+                    <script uri="ZombieKeyboard.bs" />
+                    <children>
+                        <label id="helloZombieText" />
+                    </children>
+                </component>
+            `);
+
+            program.setFile('components/ZombieKeyboard.bs', `
+                sub init()
+                    print "hello"
+                    m.top.isSameNode(m.top)
+                end sub
+            `);
+
+            validateNodeWithIDInjection(program);
+        });
+    });
+
+    it('adds assignments to existing init()', async () => {
         program.setFile('components/ZombieKeyboard.bs', `
             sub init()
                 print "hello"
@@ -52,7 +120,30 @@ describe('findnode', () => {
         `);
     });
 
-    it('it works when no bs file is present', async () => {
+    it('does not crash when component has no children', async () => {
+        program.setFile('components/ZombieKeyboard.xml', `
+            <component name="ZombieKeyboard" extends="group">
+            </component>
+        `);
+
+
+        //for this test, we need to actually run a full build because this file won't exist until after the build
+        program.validate();
+        expect(program.getDiagnostics().map(x => x.message)).to.eql([]);
+        await program.transpile([], stagingDir);
+
+        expect(
+            undent(
+                fsExtra.readFileSync(s`${stagingDir}/components/ZombieKeyboard.xml`).toString()
+            )
+        ).to.equal(undent`
+            <component name="ZombieKeyboard" extends="group">
+                <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
+            </component>
+        `);
+    });
+
+    it('creates new file when no init() was found', async () => {
         program.setFile('components/ZombieKeyboard.xml', `
             <component name="ZombieKeyboard" extends="group">
                 <children>
@@ -67,7 +158,9 @@ describe('findnode', () => {
         await program.transpile([], stagingDir);
 
         expect(
-            fsExtra.readFileSync(s`${stagingDir}/components/ZombieKeyboard.brs`).toString()
+            undent(
+                fsExtra.readFileSync(s`${stagingDir}/components/ZombieKeyboard-findnode.brs`).toString()
+            )
         ).to.equal(undent`
             sub init()
                 m.helloZombieText = m.top.findNode("helloZombieText")
@@ -79,7 +172,7 @@ describe('findnode', () => {
             undent(fsExtra.readFileSync(s`${stagingDir}/components/ZombieKeyboard.xml`).toString())
         ).to.equal(undent`
             <component name="ZombieKeyboard" extends="group">
-                <script uri="pkg:/components/ZombieKeyboard.brs" type="text/brightscript" />
+                <script uri="pkg:/components/ZombieKeyboard-findnode.brs" type="text/brightscript" />
                 <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
                 <children>
                     <label id="helloZombieText" />
@@ -88,12 +181,47 @@ describe('findnode', () => {
         `);
     });
 
-    it('it works when an empty file is present', async () => {
-        program.setFile('components/ZombieKeyboard.bs', `
+    it('it works when no init was found, but codebehind file doesbs file is present', async () => {
+        program.setFile('components/ZombieKeyboard.xml', `
+            <component name="ZombieKeyboard" extends="group">
+                <children>
+                    <label id="helloZombieText" />
+                </children>
+            </component>
         `);
 
+        //for this test, we need to actually run a full build because this file won't exist until after the build
+        program.validate();
+        expect(program.getDiagnostics().map(x => x.message)).to.eql([]);
+        await program.transpile([], stagingDir);
+
+        expect(
+            undent(fsExtra.readFileSync(s`${stagingDir}/components/ZombieKeyboard-findnode.brs`).toString())
+        ).to.equal(undent`
+            sub init()
+                m.helloZombieText = m.top.findNode("helloZombieText")
+            end sub
+        `);
+
+        //make sure the import to this new file is present in the xml file
+        expect(
+            undent(fsExtra.readFileSync(s`${stagingDir}/components/ZombieKeyboard.xml`).toString())
+        ).to.equal(undent`
+            <component name="ZombieKeyboard" extends="group">
+                <script uri="pkg:/components/ZombieKeyboard-findnode.brs" type="text/brightscript" />
+                <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
+                <children>
+                    <label id="helloZombieText" />
+                </children>
+            </component>
+        `);
+    });
+
+    it('it still generates a new file when an empty codebehind file is present', async () => {
+        program.setFile('components/ZombieKeyboard.bs', ``);
+
         program.setFile('components/ZombieKeyboard.xml', `
-            <component name="ZombieKeyboard">
+            <component name="ZombieKeyboard" extends="Group">
                 <script uri="ZombieKeyboard.bs" />
                 <children>
                     <label id="helloZombieText" />
@@ -101,13 +229,78 @@ describe('findnode', () => {
             </component>
         `);
 
-        const result = await program.getTranspiledFileContents('components/ZombieKeyboard.bs');
-        expect(result.code).to.equal(undent`
+        //for this test, we need to actually run a full build because this file won't exist until after the build
+        program.validate();
+        expect(program.getDiagnostics().map(x => x.message)).to.eql([]);
+        await program.transpile([], stagingDir);
+
+        expect(
+            undent(fsExtra.readFileSync(s`${stagingDir}/components/ZombieKeyboard-findnode.brs`).toString())
+        ).to.equal(undent`
             sub init()
                 m.helloZombieText = m.top.findNode("helloZombieText")
             end sub
         `);
     });
+
+    it('it uses sequence number in generated filename when necessary', async () => {
+        program.setFile('components/ZombieKeyboard-findnode.brs', `'original contents`);
+
+        program.setFile('components/ZombieKeyboard.xml', `
+            <component name="ZombieKeyboard" extends="Group">
+                <script uri="pkg:/components/ZombieKeyboard-findnode.brs" />
+                <children>
+                    <label id="helloZombieText" />
+                </children>
+            </component>
+        `);
+
+        //for this test, we need to actually run a full build because this file won't exist until after the build
+        program.validate();
+        expect(program.getDiagnostics().map(x => x.message)).to.eql([]);
+        await program.transpile([], stagingDir);
+
+        expect(
+            undent(fsExtra.readFileSync(s`${stagingDir}/components/ZombieKeyboard-findnode.brs`).toString())
+        ).to.equal(undent`'original contents`);
+        expect(
+            undent(fsExtra.readFileSync(s`${stagingDir}/components/ZombieKeyboard-findnode-2.brs`).toString())
+        ).to.equal(undent`
+            sub init()
+                m.helloZombieText = m.top.findNode("helloZombieText")
+            end sub
+        `);
+    });
+
+    it('it uses sequence number in generated filename when necessary', async () => {
+        program.setFile('components/ZombieKeyboard-findnode.bs', `'original contents`);
+
+        program.setFile('components/ZombieKeyboard.xml', `
+            <component name="ZombieKeyboard" extends="Group">
+                <script uri="pkg:/components/ZombieKeyboard-findnode.bs" />
+                <children>
+                    <label id="helloZombieText" />
+                </children>
+            </component>
+        `);
+
+        //for this test, we need to actually run a full build because this file won't exist until after the build
+        program.validate();
+        expect(program.getDiagnostics().map(x => x.message)).to.eql([]);
+        await program.transpile([], stagingDir);
+
+        expect(
+            undent(fsExtra.readFileSync(s`${stagingDir}/components/ZombieKeyboard-findnode.brs`).toString())
+        ).to.equal(undent`'original contents`);
+        expect(
+            undent(fsExtra.readFileSync(s`${stagingDir}/components/ZombieKeyboard-findnode-2.brs`).toString())
+        ).to.equal(undent`
+            sub init()
+                m.helloZombieText = m.top.findNode("helloZombieText")
+            end sub
+        `);
+    });
+
 
     it('it works when a file is present with an empty init function', async () => {
         program.setFile('components/ZombieKeyboard.bs', `
@@ -227,7 +420,7 @@ describe('findnode', () => {
         }]);
     });
 
-    it('it works when you extend a component and founds nodes are declared within their correct component', async () => {
+    it('it works when you extend a component and found nodes are declared within their correct component', async () => {
         program.setFile('components/BaseKeyboard.xml', `
             <component name="BaseKeyboard" extends="group">
                 <children>
@@ -250,15 +443,23 @@ describe('findnode', () => {
             </component>
         `);
 
-        let result = await program.getTranspiledFileContents('components/BaseKeyboard.bs');
-        expect(result.code).to.equal(undent`
+        //for this test, we need to actually run a full build because this file won't exist until after the build
+        program.validate();
+        expect(program.getDiagnostics().map(x => x.message)).to.eql([]);
+        await program.transpile([], stagingDir);
+
+        expect(
+            undent(fsExtra.readFileSync(s`${stagingDir}/components/BaseKeyboard-findnode.brs`).toString())
+        ).to.equal(undent`
             sub init()
                 m.helloText = m.top.findNode("helloText")
             end sub
         `);
 
-        result = await program.getTranspiledFileContents('components/ZombieKeyboard.bs');
-        expect(result.code).to.equal(undent`
+
+        expect(
+            undent(fsExtra.readFileSync(s`${stagingDir}/components/ZombieKeyboard.brs`).toString())
+        ).to.equal(undent`
             sub init()
                 m.helloText.text = "HELLO ZOMBIE"
             end sub

--- a/src/findNodes.ts
+++ b/src/findNodes.ts
@@ -1,17 +1,15 @@
-import type { AstEditor, FunctionStatement, BrsFile, Program, BscFile, Range, TranspileObj } from 'brighterscript';
+import type { AstEditor, FunctionStatement, BrsFile, Program, BscFile, Range, TranspileObj, Scope, XmlFile } from 'brighterscript';
 import { isBrsFile, Parser, isXmlScope, DiagnosticSeverity, createVisitor, WalkMode, isDottedGetExpression, isVariableExpression, isLiteralString, util, createSGAttribute } from 'brighterscript';
 import { SGScript, type SGNode } from 'brighterscript/dist/parser/SGTypes';
 
-function findChildrenWithIDs(children: Array<SGNode>): Map<string, Range> {
+export function findChildrenWithIDs(children: Array<SGNode>): Map<string, Range> {
     let foundIDs = new Map<string, Range>();
-    if (children) {
-        children.forEach(child => {
-            if (child.id) {
-                foundIDs.set(child.id, child.attributes.find(x => x.key.text === 'id')?.value?.range ?? util.createRange(0, 0, 0, 100));
-            }
-            const subChildren = findChildrenWithIDs(child.children);
-            foundIDs = new Map([...foundIDs, ...subChildren]);
-        });
+    for (const child of children ?? []) {
+        if (child.id) {
+            foundIDs.set(child.id, child.attributes?.find?.(x => x.key.text === 'id')?.value?.range ?? util.createRange(0, 0, 0, 100));
+        }
+        const subChildren = findChildrenWithIDs(child.children);
+        foundIDs = new Map([...foundIDs, ...subChildren]);
     }
     return foundIDs;
 }
@@ -21,58 +19,48 @@ export function findNodeWithIDInjection(program: Program, entries: TranspileObj[
         if (isXmlScope(scope)) {
             const xmlFile = scope.xmlFile;
             const ids = findChildrenWithIDs(xmlFile.parser.ast.component?.children?.children ?? []);
-            if (ids.size > 0) {
-                const scopeFiles: BscFile[] = scope.getOwnFiles();
 
-                //find an init function from all the scope's files
-                let initFunction: FunctionStatement | undefined;
+            //skip this xml file if there are no nodes with IDs in it
+            if (ids.size === 0) {
+                continue;
+            }
 
-                let brsFileWithInit: BrsFile | undefined;
-                for (const file of scopeFiles) {
-                    if (isBrsFile(file)) {
-                        initFunction = file.parser.references.functionStatementLookup.get('init');
-                        if (initFunction) {
-                            brsFileWithInit = file;
-                            break;
-                        }
-                    }
-                }
+            //build the list of assignments
+            const assignments = Array.from(ids).map(([id, range]) => {
+                return `m.${id} = m.top.findNode("${id}")`;
+            }).join('\n');
 
-                //if we don't have any brs files with an init, then we need to make a new BrsFile that we can add the `init()` function to
-                if (!brsFileWithInit) {
-                    brsFileWithInit = program.setFile<BrsFile>(xmlFile.pkgPath.replace('.xml', '.bs'), '');
-                    createdFiles.push(brsFileWithInit);
+            const initFunctionText = `
+                sub init()
+                    ${assignments}
+                end sub
+            `;
 
-                    //add this import to the xml file
-                    editor.arrayPush(xmlFile.parser.ast.component!.scripts, new SGScript({
-                        text: 'script'
-                    }, [
-                        createSGAttribute('uri', util.sanitizePkgPath(brsFileWithInit.pkgPath))
-                    ]));
-                }
+            const initFunctionInfo = findInitFunction(scope);
 
-                //create an init function if it's missing
-                if (!initFunction) {
-                    brsFileWithInit = program.getFiles<BrsFile>(xmlFile.possibleCodebehindPkgPaths).find(x => !!x);
-                    initFunction = Parser.parse(`sub init()\nend sub`).ast.statements[0] as FunctionStatement;
-                    if (brsFileWithInit) {
-                        editor.arrayPush(brsFileWithInit.parser.ast.statements, initFunction);
-                    }
-                }
+            //if we found an init function, inject the assignments
+            if (initFunctionInfo) {
+                //add the assignments to the top of the init function
+                editor.arrayUnshift(
+                    initFunctionInfo.initFunction.func.body.statements,
+                    ...(Parser.parse(initFunctionText).ast.statements[0] as FunctionStatement).func.body.statements
+                );
 
-                if (brsFileWithInit && initFunction) {
-                    //add m variables for every xml component that has an id
-                    // eslint-disable-next-line max-statements-per-line, @typescript-eslint/brace-style
-                    const assignments = Array.from(ids).map(([id, range]) => { return `m.${id} = m.top.findNode("${id}")`; }).join('\n');
-                    const parser = Parser.parse(`
-                        sub temp()
-                            ${assignments}
-                        end sub
-                    `);
-                    const statements = (parser.ast.statements[0] as FunctionStatement).func.body.statements;
-                    //add the assignments to the top of the init function
-                    editor.arrayUnshift(initFunction.func.body.statements, ...statements);
-                }
+                //we don't have an init function, create a new file and insert an empty init function into it
+            } else {
+                //get a unique filename for the new file
+                const pkgPath = getUniqueFilename(xmlFile, program);
+
+                //create and add the new file to the program
+                const brsFileWithInit = program.setFile<BrsFile>(pkgPath, initFunctionText);
+                createdFiles.push(brsFileWithInit);
+
+                //import this file into the current xml file
+                editor.arrayPush(xmlFile.parser.ast.component!.scripts, new SGScript({
+                    text: 'script'
+                }, [
+                    createSGAttribute('uri', util.sanitizePkgPath(brsFileWithInit.pkgPath))
+                ]));
             }
         }
     }
@@ -84,20 +72,7 @@ export function validateNodeWithIDInjection(program: Program) {
             const xmlFile = scope.xmlFile;
             const ids = findChildrenWithIDs(xmlFile.parser.ast.component?.children?.children ?? []);
             if (ids.size > 0) {
-                const scopeFiles: BscFile[] = scope.getOwnFiles();
-
-                let initFunction: FunctionStatement | undefined;
-                let initFunctionFile: BscFile | undefined;
-
-                for (const file of scopeFiles) {
-                    if (isBrsFile(file)) {
-                        initFunction = file.parser.references.functionStatementLookup.get('init');
-                        if (initFunction) {
-                            initFunctionFile = file;
-                            break;
-                        }
-                    }
-                }
+                const { initFunction, file: initFunctionFile } = findInitFunction(scope) ?? {};
 
                 if (initFunction && initFunctionFile) {
                     initFunction.func.body.walk(createVisitor({
@@ -135,4 +110,38 @@ export function validateNodeWithIDInjection(program: Program) {
             }
         }
     }
+}
+
+/**
+ * Find the first function called `init()` across all files in a scope
+ */
+function findInitFunction(scope: Scope): { file: BscFile; initFunction: FunctionStatement } | undefined {
+    for (const file of scope.getOwnFiles()) {
+        if (isBrsFile(file)) {
+            const initFunction = file.parser.references.functionStatementLookup.get('init');
+            if (initFunction) {
+                return {
+                    initFunction: initFunction,
+                    file: file
+                };
+            }
+        }
+    }
+}
+
+/**
+ * Get a pkgPath for a new brs file that will sit next to the given xml file. This is deterministic,
+ * so if the file already exists, we'll append the next available number number to the end of the filename to make it unique.
+ * @param file
+ * @param program
+ */
+function getUniqueFilename(file: XmlFile, program: Program) {
+    let pkgPath = file.pkgPath.replace('.xml', '-findnode');
+    let sequence = 2;
+
+    //try up to 10 times to find a unique filename within the program
+    while (sequence < 10 && program.hasFile(`${pkgPath}.brs`) || program.hasFile(`${pkgPath}.bs`)) {
+        pkgPath = file.pkgPath.replace('.xml', `-findnode-${sequence++}`);
+    }
+    return `${pkgPath}.brs`;
 }


### PR DESCRIPTION
Instead of assuming the codebehind file will always be the xml file name but with `.brs` extension, we now generate a totally new file name that is guaranteed to be unique.  (i.e. `SomeComponent-findnode.brs`).

This has the added benefit of also avoiding overwriting the actual codebehind file if it exists but without an `init()` function.