### PR TITLE
Ignore unimportant files during npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,17 @@
+.vscode
+.git
+.nyc_output
+coverage
+dist/**/*.spec.*
+dist/**/*.tsbuildinfo
+src
+testProject
+.gitignore
+.travis.yml
+rokudeploy.json
+*.pkg
+tsconfig.json
+tslint.json
+bsconfig.json
+.github/**/*
+.eslintrc.js


### PR DESCRIPTION
Only include relevant files when building the npm package