### PR TITLE
0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [0.1.5](https://github.com/rokucommunity/bsc-plugin-auto-findnode/compare/0.1.4...v0.1.5) - 2025-06-09
+### Added
+ - added [brighterscript@0.69.10](https://github.com/rokucommunity/brighterscript)
+
+
+
 ## [0.1.4](https://github.com/rokucommunity/bsc-plugin-auto-findnode/compare/0.1.3...v0.1.4) - 2025-06-03
 ### Changed
  - upgrade to [brighterscript@0.69.10](https://github.com/rokucommunity/brighterscript/blob/master/CHANGELOG.md#06910---2025-06-03). Notable changes since 0.69.7:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bsc-plugin-auto-findnode",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bsc-plugin-auto-findnode",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "ISC",
       "devDependencies": {
         "@types/chai": "^4.3.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsc-plugin-auto-findnode",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A BrighterScript plugin that auto-injects `m.top.findNode()` calls in your component `init()` functions",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This PR creates the `v0.1.5` release of `bsc-plugin-auto-findnode`. Here are some useful links:
- [GitHub Draft Release](https://github.com/rokucommunity/bsc-plugin-auto-findnode/releases/tag/untagged-475a8034945e80134299)
- [Edit changelog](https://github.com/rokucommunity/bsc-plugin-auto-findnode/edit/release/0.1.5/CHANGELOG.md?pr=/rokucommunity/bsc-plugin-auto-findnode/pull/22)
- [See what's changed](https://github.com/rokucommunity/bsc-plugin-auto-findnode/compare/v0.1.4...release/0.1.5)

Click [here](https://github.com/rokucommunity/bsc-plugin-auto-findnode/releases/download/v0.0.0-packages/bsc-plugin-auto-findnode-0.1.5-release_0.1.5.20250609195425.tgz) to download a temporary npm package based on 67be0e5, or install with this command:
 ```bash
npm install https://github.com/rokucommunity/bsc-plugin-auto-findnode/releases/download/v0.0.0-packages/bsc-plugin-auto-findnode-0.1.5-release_0.1.5.20250609195425.tgz
```